### PR TITLE
Local allocation prototype: initial type system plumbing and backend support

### DIFF
--- a/asmcomp/CSEgen.ml
+++ b/asmcomp/CSEgen.ml
@@ -236,6 +236,7 @@ method class_of_operation op =
   | Ifloatofint | Iintoffloat -> Op_pure
   | Ispecific _ -> Op_other
   | Iname_for_debugger _ -> Op_pure
+  | Ibeginregion | Iendregion -> Op_other
 
 (* Operations that are so cheap that it isn't worth factoring them. *)
 

--- a/asmcomp/afl_instrument.ml
+++ b/asmcomp/afl_instrument.ml
@@ -88,6 +88,7 @@ and instrument = function
      in
      Ccatch (isrec, cases, instrument body)
   | Cexit (ex, args) -> Cexit (ex, List.map instrument args)
+  | Cregion e -> Cregion (instrument e)
 
   (* these are base cases and have no logging *)
   | Cconst_int _ | Cconst_natint _ | Cconst_float _

--- a/asmcomp/amd64/CSE.ml
+++ b/asmcomp/amd64/CSE.ml
@@ -29,8 +29,6 @@ method! class_of_operation op =
     begin match spec with
     | Ilea _ | Isextend32 | Izextend32 -> Op_pure
     | Istore_int(_, _, is_asg) -> Op_store is_asg
-    | Iregionbegin -> Op_load
-    | Iregionend -> Op_store true
     | Ioffset_loc(_, _) -> Op_store true
     | Ifloatarithmem _ | Ifloatsqrtf _ -> Op_load
     | Ibswap _ | Isqrtf -> super#class_of_operation op

--- a/asmcomp/amd64/CSE.ml
+++ b/asmcomp/amd64/CSE.ml
@@ -29,6 +29,8 @@ method! class_of_operation op =
     begin match spec with
     | Ilea _ | Isextend32 | Izextend32 -> Op_pure
     | Istore_int(_, _, is_asg) -> Op_store is_asg
+    | Iregionbegin -> Op_load
+    | Iregionend -> Op_store true
     | Ioffset_loc(_, _) -> Op_store true
     | Ifloatarithmem _ | Ifloatsqrtf _ -> Op_load
     | Ibswap _ | Isqrtf -> super#class_of_operation op

--- a/asmcomp/amd64/arch.ml
+++ b/asmcomp/amd64/arch.ml
@@ -46,8 +46,6 @@ type specific_operation =
                                           extension *)
   | Izextend32                         (* 32 to 64 bit conversion with zero
                                           extension *)
-  | Iregionbegin
-  | Iregionend
 
 and float_operation =
     Ifloatadd | Ifloatsub | Ifloatmul | Ifloatdiv
@@ -135,10 +133,6 @@ let print_specific_operation printreg op ppf arg =
       fprintf ppf "sextend32 %a" printreg arg.(0)
   | Izextend32 ->
       fprintf ppf "zextend32 %a" printreg arg.(0)
-  | Iregionbegin ->
-      fprintf ppf "iregionbegin"
-  | Iregionend ->
-      fprintf ppf "iregionend %a" printreg arg.(0)
 
 let win64 =
   match Config.system with

--- a/asmcomp/amd64/arch.ml
+++ b/asmcomp/amd64/arch.ml
@@ -46,6 +46,8 @@ type specific_operation =
                                           extension *)
   | Izextend32                         (* 32 to 64 bit conversion with zero
                                           extension *)
+  | Iregionbegin
+  | Iregionend
 
 and float_operation =
     Ifloatadd | Ifloatsub | Ifloatmul | Ifloatdiv
@@ -133,6 +135,10 @@ let print_specific_operation printreg op ppf arg =
       fprintf ppf "sextend32 %a" printreg arg.(0)
   | Izextend32 ->
       fprintf ppf "zextend32 %a" printreg arg.(0)
+  | Iregionbegin ->
+      fprintf ppf "iregionbegin"
+  | Iregionend ->
+      fprintf ppf "iregionend %a" printreg arg.(0)
 
 let win64 =
   match Config.system with

--- a/asmcomp/amd64/emit.mlp
+++ b/asmcomp/amd64/emit.mlp
@@ -754,9 +754,9 @@ let emit_instr fallthrough i =
       I.movsxd (arg32 i 0) (res i 0)
   | Lop(Ispecific(Izextend32)) ->
       I.mov (arg32 i 0) (res32 i 0)
-  | Lop(Ispecific(Iregionbegin)) ->
+  | Lop(Ibeginregion) ->
       I.mov (domain_field Domainstate.Domain_local_sp) (res i 0)
-  | Lop(Ispecific(Iregionend)) ->
+  | Lop(Iendregion) ->
       I.mov (arg i 0) (domain_field Domainstate.Domain_local_sp)
   | Lop (Iname_for_debugger _) -> ()
   | Lreloadretaddr ->

--- a/asmcomp/amd64/emit.mlp
+++ b/asmcomp/amd64/emit.mlp
@@ -279,6 +279,19 @@ let emit_call_gc gc =
   def_label gc.gc_frame;
   I.jmp (label gc.gc_return_lbl)
 
+(* Record calls to local stack reallocation *)
+
+type local_realloc_call =
+  { lr_lbl: label;
+    lr_return_lbl: label; }
+
+let local_realloc_sites = ref ([] : local_realloc_call list)
+
+let emit_local_realloc lr =
+  def_label lr.lr_lbl;
+  emit_call "caml_call_local_realloc";
+  I.jmp (label lr.lr_return_lbl)
+
 (* Record calls to caml_ml_array_bound_error.
    In -g mode we maintain one call to
    caml_ml_array_bound_error per bound check site.  Without -g, we can share
@@ -657,12 +670,15 @@ let emit_instr fallthrough i =
       (* FIXME: before or after check? Calling conv w/ realloc *)
       I.mov r (domain_field Domainstate.Domain_local_sp);
       I.cmp (domain_field Domainstate.Domain_local_limit) r;
-      let lbl_ok = new_label () in
-      I.j GE (label lbl_ok);
-      emit_call "caml_call_local_realloc";
-      def_label lbl_ok;
+      let lbl_call = new_label () in
+      I.j L (label lbl_call);
+      let lbl_after_alloc = new_label () in
+      def_label lbl_after_alloc;
       I.add (domain_field Domainstate.Domain_local_top) r;
       I.add (int 8) r;
+      local_realloc_sites :=
+        { lr_lbl = lbl_call;
+          lr_return_lbl = lbl_after_alloc } :: !local_realloc_sites
   | Lop(Iintop(Icomp cmp)) ->
       I.cmp (arg i 1) (arg i 0);
       I.set (cond cmp) al;
@@ -885,6 +901,7 @@ let fundecl fundecl =
   tailrec_entry_point := fundecl.fun_tailrec_entry_point_label;
   stack_offset := 0;
   call_gc_sites := [];
+  local_realloc_sites := [];
   bound_error_sites := [];
   bound_error_call := 0;
   for i = 0 to Proc.num_register_classes - 1 do
@@ -908,6 +925,7 @@ let fundecl fundecl =
   cfi_startproc ();
   emit_all true fundecl.fun_body;
   List.iter emit_call_gc !call_gc_sites;
+  List.iter emit_local_realloc !local_realloc_sites;
   emit_call_bound_errors ();
   if !frame_required then begin
     let n = frame_size() - 8 - (if fp then 8 else 0) in

--- a/asmcomp/amd64/emit.mlp
+++ b/asmcomp/amd64/emit.mlp
@@ -619,7 +619,7 @@ let emit_instr fallthrough i =
       | Double | Double_u ->
           I.movsd (arg i 0) (addressing addr REAL8 i 1)
       end
-  | Lop(Ialloc { bytes = n; dbginfo }) ->
+  | Lop(Ialloc { bytes = n; dbginfo; mode = Alloc_heap }) ->
       assert (n <= (Config.max_young_wosize + 1) * Arch.size_addr);
       if !fastcode_flag then begin
         I.sub (int n) r15;
@@ -649,6 +649,20 @@ let emit_instr fallthrough i =
         def_label label;
         I.lea (mem64 NONE 8 R15) (res i 0)
       end
+  | Lop(Ialloc { bytes = n; dbginfo=_; mode = Alloc_local }) ->
+      assert (n <= (Config.max_young_wosize + 1) * Arch.size_addr);
+      let r = res i 0 in
+      I.mov (domain_field Domainstate.Domain_local_sp) r;
+      I.sub (int n) r;
+      (* FIXME: before or after check? Calling conv w/ realloc *)
+      I.mov r (domain_field Domainstate.Domain_local_sp);
+      I.cmp (domain_field Domainstate.Domain_local_limit) r;
+      let lbl_ok = new_label () in
+      I.j GE (label lbl_ok);
+      emit_call "caml_call_local_realloc";
+      def_label lbl_ok;
+      I.add (domain_field Domainstate.Domain_local_top) r;
+      I.add (int 8) r;
   | Lop(Iintop(Icomp cmp)) ->
       I.cmp (arg i 1) (arg i 0);
       I.set (cond cmp) al;
@@ -724,6 +738,10 @@ let emit_instr fallthrough i =
       I.movsxd (arg32 i 0) (res i 0)
   | Lop(Ispecific(Izextend32)) ->
       I.mov (arg32 i 0) (res32 i 0)
+  | Lop(Ispecific(Iregionbegin)) ->
+      I.mov (domain_field Domainstate.Domain_local_sp) (res i 0)
+  | Lop(Ispecific(Iregionend)) ->
+      I.mov (arg i 0) (domain_field Domainstate.Domain_local_sp)
   | Lop (Iname_for_debugger _) -> ()
   | Lreloadretaddr ->
       ()

--- a/asmcomp/amd64/proc.ml
+++ b/asmcomp/amd64/proc.ml
@@ -357,6 +357,7 @@ let op_is_pure = function
   | Iintop(Icheckbound) | Iintop_imm(Icheckbound, _) -> false
   | Ispecific(Ilea _|Isextend32|Izextend32) -> true
   | Ispecific _ -> false
+  | Ibeginregion | Iendregion -> false
   | _ -> true
 
 (* Layout of the stack frame *)

--- a/asmcomp/amd64/selection.ml
+++ b/asmcomp/amd64/selection.ml
@@ -245,8 +245,6 @@ method! select_operation op args dbg =
       Ispecific Izextend32, [arg]
     | _ -> super#select_operation op args dbg
     end
-  | Cbeginregion -> Ispecific Iregionbegin, args
-  | Cendregion -> Ispecific Iregionend, args
   | _ -> super#select_operation op args dbg
 
 (* Recognize float arithmetic with mem *)

--- a/asmcomp/amd64/selection.ml
+++ b/asmcomp/amd64/selection.ml
@@ -245,6 +245,8 @@ method! select_operation op args dbg =
       Ispecific Izextend32, [arg]
     | _ -> super#select_operation op args dbg
     end
+  | Cbeginregion -> Ispecific Iregionbegin, args
+  | Cendregion -> Ispecific Iregionend, args
   | _ -> super#select_operation op args dbg
 
 (* Recognize float arithmetic with mem *)

--- a/asmcomp/cmm.ml
+++ b/asmcomp/cmm.ml
@@ -152,7 +152,7 @@ and operation =
     Capply of machtype
   | Cextcall of string * machtype * exttype list * bool
   | Cload of memory_chunk * Asttypes.mutable_flag
-  | Calloc
+  | Calloc of Lambda.alloc_mode
   | Cstore of memory_chunk * Lambda.initialization_or_assignment
   | Caddi | Csubi | Cmuli | Cmulhi | Cdivi | Cmodi
   | Cand | Cor | Cxor | Clsl | Clsr | Casr
@@ -165,6 +165,8 @@ and operation =
   | Ccmpf of float_comparison
   | Craise of Lambda.raise_kind
   | Ccheckbound
+  | Cbeginregion
+  | Cendregion
 
 type expression =
     Cconst_int of int * Debuginfo.t

--- a/asmcomp/cmm.mli
+++ b/asmcomp/cmm.mli
@@ -145,7 +145,7 @@ and operation =
           The [exttype list] describes the unboxing types of the arguments.
           An empty list means "all arguments are machine words [XInt]". *)
   | Cload of memory_chunk * Asttypes.mutable_flag
-  | Calloc
+  | Calloc of Lambda.alloc_mode
   | Cstore of memory_chunk * Lambda.initialization_or_assignment
   | Caddi | Csubi | Cmuli | Cmulhi | Cdivi | Cmodi
   | Cand | Cor | Cxor | Clsl | Clsr | Casr
@@ -162,6 +162,8 @@ and operation =
                    then the index.
                    It results in a bounds error if the index is greater than
                    or equal to the bound. *)
+  | Cbeginregion
+  | Cendregion
 
 (** Every basic block should have a corresponding [Debuginfo.t] for its
     beginning. *)

--- a/asmcomp/cmm.mli
+++ b/asmcomp/cmm.mli
@@ -162,8 +162,6 @@ and operation =
                    then the index.
                    It results in a bounds error if the index is greater than
                    or equal to the bound. *)
-  | Cbeginregion
-  | Cendregion
 
 (** Every basic block should have a corresponding [Debuginfo.t] for its
     beginning. *)
@@ -195,6 +193,7 @@ and expression =
   | Cexit of int * expression list
   | Ctrywith of expression * Backend_var.With_provenance.t * expression
       * Debuginfo.t
+  | Cregion of expression
 
 type codegen_option =
   | Reduce_code_size
@@ -247,6 +246,9 @@ val map_tail: (expression -> expression) -> expression -> expression
       to all inner sub-expressions that can produce the final result.
       Same disclaimer as for [iter_shallow_tail] about the notion
       of "tail" sub-expression. *)
+
+val iter_shallow: (expression -> unit) -> expression -> unit
+  (** Apply the transformation to each immediate sub-expression. *)
 
 val map_shallow: (expression -> expression) -> expression -> expression
   (** Apply the transformation to each immediate sub-expression. *)

--- a/asmcomp/cmm_helpers.mli
+++ b/asmcomp/cmm_helpers.mli
@@ -576,6 +576,9 @@ val send :
   Lambda.meth_kind -> expression -> expression -> expression list ->
   Debuginfo.t -> expression
 
+(** Construct [Cregion e], eliding some useless regions *)
+val region : expression -> expression
+
 (** Generic Cmm fragments *)
 
 (** Generate generic functions *)

--- a/asmcomp/cmm_helpers.mli
+++ b/asmcomp/cmm_helpers.mli
@@ -299,7 +299,8 @@ val call_cached_method :
 (** Allocations *)
 
 (** Allocate a block of regular values with the given tag *)
-val make_alloc : Debuginfo.t -> int -> expression list -> expression
+val make_alloc :
+  ?mode:Lambda.alloc_mode -> Debuginfo.t -> int -> expression list -> expression
 
 (** Allocate a block of unboxed floats with the given tag *)
 val make_float_alloc : Debuginfo.t -> int -> expression list -> expression

--- a/asmcomp/cmmgen.ml
+++ b/asmcomp/cmmgen.ml
@@ -556,7 +556,7 @@ let rec transl env e =
          | Pandbint _ | Porbint _ | Pxorbint _ | Plslbint _ | Plsrbint _
          | Pasrbint _ | Pbintcomp (_, _) | Pstring_load _ | Pbytes_load _
          | Pbytes_set _ | Pbigstring_load _ | Pbigstring_set _
-         | Pbbswap _ | Pendregion), _)
+         | Pbbswap _), _)
         ->
           fatal_error "Cmmgen.transl:prim"
       end
@@ -672,8 +672,8 @@ let rec transl env e =
   | Uunreachable ->
       let dbg = Debuginfo.none in
       Cop(Cload (Word_int, Mutable), [Cconst_int (0, dbg)], dbg)
-  | Ubeginregion (r, e) ->
-      Clet (r, Cop (Cbeginregion, [], Debuginfo.none), transl env e)
+  | Uregion e ->
+      region (transl env e)
 
 and transl_catch env nfail ids body handler dbg =
   let ids = List.map (fun (id, kind) -> (id, kind, ref No_result)) ids in
@@ -846,8 +846,6 @@ and transl_prim_1 env p arg dbg =
   | Pbswap16 ->
       tag_int (bswap16 (ignore_high_bit_int (untag_int
         (transl env arg) dbg)) dbg) dbg
-  | Pendregion ->
-      Cop(Cendregion, [transl env arg], dbg)
   | (Pfield_computed | Psequand | Psequor
     | Paddint | Psubint | Pmulint | Pandint
     | Porint | Pxorint | Plslint | Plsrint | Pasrint
@@ -1041,7 +1039,7 @@ and transl_prim_2 env p arg1 arg2 dbg =
   | Pmakearray (_, _) | Pduparray (_, _) | Parraylength _ | Parraysetu _
   | Parraysets _ | Pbintofint _ | Pintofbint _ | Pcvtbint (_, _)
   | Pnegbint _ | Pbigarrayref (_, _, _, _) | Pbigarrayset (_, _, _, _)
-  | Pbigarraydim _ | Pbytes_set _ | Pbigstring_set _ | Pbbswap _ | Pendregion
+  | Pbigarraydim _ | Pbytes_set _ | Pbigstring_set _ | Pbbswap _
     ->
       fatal_errorf "Cmmgen.transl_prim_2: %a"
         Printclambda_primitives.primitive p
@@ -1100,7 +1098,7 @@ and transl_prim_3 env p arg1 arg2 arg3 dbg =
   | Psubbint _ | Pmulbint _ | Pdivbint _ | Pmodbint _ | Pandbint _ | Porbint _
   | Pxorbint _ | Plslbint _ | Plsrbint _ | Pasrbint _ | Pbintcomp (_, _)
   | Pbigarrayref (_, _, _, _) | Pbigarrayset (_, _, _, _) | Pbigarraydim _
-  | Pstring_load _ | Pbytes_load _ | Pbigstring_load _ | Pbbswap _ | Pendregion
+  | Pstring_load _ | Pbytes_load _ | Pbigstring_load _ | Pbbswap _
     ->
       fatal_errorf "Cmmgen.transl_prim_3: %a"
         Printclambda_primitives.primitive p

--- a/asmcomp/mach.ml
+++ b/asmcomp/mach.ml
@@ -53,7 +53,8 @@ type operation =
   | Istackoffset of int
   | Iload of Cmm.memory_chunk * Arch.addressing_mode
   | Istore of Cmm.memory_chunk * Arch.addressing_mode * bool
-  | Ialloc of { bytes : int; dbginfo : Debuginfo.alloc_dbginfo; }
+  | Ialloc of { bytes : int; dbginfo : Debuginfo.alloc_dbginfo;
+                mode : Lambda.alloc_mode }
   | Iintop of integer_operation
   | Iintop_imm of integer_operation * int
   | Inegf | Iabsf | Iaddf | Isubf | Imulf | Idivf

--- a/asmcomp/mach.ml
+++ b/asmcomp/mach.ml
@@ -62,6 +62,7 @@ type operation =
   | Ispecific of Arch.specific_operation
   | Iname_for_debugger of { ident : Backend_var.t; which_parameter : int option;
       provenance : unit option; is_assignment : bool; }
+  | Ibeginregion | Iendregion
 
 type instruction =
   { desc: instruction_desc;

--- a/asmcomp/mach.mli
+++ b/asmcomp/mach.mli
@@ -54,7 +54,8 @@ type operation =
   | Iload of Cmm.memory_chunk * Arch.addressing_mode
   | Istore of Cmm.memory_chunk * Arch.addressing_mode * bool
                                  (* false = initialization, true = assignment *)
-  | Ialloc of { bytes : int; dbginfo : Debuginfo.alloc_dbginfo; }
+  | Ialloc of { bytes : int; dbginfo : Debuginfo.alloc_dbginfo;
+                mode: Lambda.alloc_mode }
   | Iintop of integer_operation
   | Iintop_imm of integer_operation * int
   | Inegf | Iabsf | Iaddf | Isubf | Imulf | Idivf

--- a/asmcomp/mach.mli
+++ b/asmcomp/mach.mli
@@ -69,6 +69,7 @@ type operation =
         (b) If [is_assignment] is [true], any information about other [Reg.t]s
             that have been previously deemed to hold the value of that
             identifier is forgotten. *)
+  | Ibeginregion | Iendregion
 
 type instruction =
   { desc: instruction_desc;

--- a/asmcomp/printcmm.ml
+++ b/asmcomp/printcmm.ml
@@ -120,7 +120,8 @@ let operation d = function
       Printf.sprintf "extcall \"%s\"%s" lbl (location d)
   | Cload (c, Asttypes.Immutable) -> Printf.sprintf "load %s" (chunk c)
   | Cload (c, Asttypes.Mutable) -> Printf.sprintf "load_mut %s" (chunk c)
-  | Calloc -> "alloc" ^ location d
+  | Calloc Alloc_heap -> "alloc" ^ location d
+  | Calloc Alloc_local -> "alloc_local" ^ location d
   | Cstore (c, init) ->
     let init =
       match init with
@@ -156,6 +157,8 @@ let operation d = function
   | Ccmpf c -> Printf.sprintf "%sf" (float_comparison c)
   | Craise k -> Lambda.raise_kind k ^ location d
   | Ccheckbound -> "checkbound" ^ location d
+  | Cbeginregion -> "beginregion" ^ location d
+  | Cendregion -> "endregion" ^ location d
 
 let rec expr ppf = function
   | Cconst_int (n, _dbg) -> fprintf ppf "%i" n

--- a/asmcomp/printcmm.ml
+++ b/asmcomp/printcmm.ml
@@ -157,8 +157,6 @@ let operation d = function
   | Ccmpf c -> Printf.sprintf "%sf" (float_comparison c)
   | Craise k -> Lambda.raise_kind k ^ location d
   | Ccheckbound -> "checkbound" ^ location d
-  | Cbeginregion -> "beginregion" ^ location d
-  | Cendregion -> "endregion" ^ location d
 
 let rec expr ppf = function
   | Cconst_int (n, _dbg) -> fprintf ppf "%i" n
@@ -268,6 +266,8 @@ let rec expr ppf = function
   | Ctrywith(e1, id, e2, _dbg) ->
       fprintf ppf "@[<2>(try@ %a@;<1 -2>with@ %a@ %a)@]"
              sequence e1 VP.print id sequence e2
+  | Cregion e ->
+      fprintf ppf "@[<2>(region@ %a)@]" sequence e
 
 and sequence ppf = function
   | Csequence(e1, e2) -> fprintf ppf "%a@ %a" sequence e1 sequence e2

--- a/asmcomp/printmach.ml
+++ b/asmcomp/printmach.ml
@@ -151,6 +151,8 @@ let operation op arg ppf res =
         | None -> ""
         | Some index -> sprintf "[P%d]" index)
       reg arg.(0)
+  | Ibeginregion -> fprintf ppf "beginregion"
+  | Iendregion -> fprintf ppf "endregion %a" reg arg.(0)
   | Ispecific op ->
       Arch.print_specific_operation reg op ppf arg
 

--- a/bytecomp/bytegen.ml
+++ b/bytecomp/bytegen.ml
@@ -130,7 +130,8 @@ let preserve_tailcall_for_prim = function
   | Pbytes_load_32 _ | Pbytes_load_64 _ | Pbytes_set_16 _ | Pbytes_set_32 _
   | Pbytes_set_64 _ | Pbigstring_load_16 _ | Pbigstring_load_32 _
   | Pbigstring_load_64 _ | Pbigstring_set_16 _ | Pbigstring_set_32 _
-  | Pbigstring_set_64 _ | Pctconst _ | Pbswap16 | Pbbswap _ | Pint_as_pointer ->
+  | Pbigstring_set_64 _ | Pctconst _ | Pbswap16 | Pbbswap _ | Pint_as_pointer
+  | Pendregion ->
       false
 
 (* Add a Kpop N instruction in front of a continuation *)
@@ -779,7 +780,7 @@ let rec comp_expr env exp sz cont =
         | CFnge -> Kccall("caml_ge_float", 2) :: Kboolnot :: cont
       in
       comp_args env args sz cont
-  | Lprim(Pmakeblock(tag, _mut, _), args, loc) ->
+  | Lprim(Pmakeblock(tag, _mut, _, _), args, loc) ->
       let cont = add_pseudo_event loc !compunit_name cont in
       comp_args env args sz (Kmakeblock(List.length args, tag) :: cont)
   | Lprim(Pfloatfield n, args, loc) ->
@@ -988,6 +989,8 @@ let rec comp_expr env exp sz cont =
           comp_expr env lam sz cont
       end
   | Lifused (_, exp) ->
+      comp_expr env exp sz cont
+  | Lbeginregion (_, exp) ->
       comp_expr env exp sz cont
 
 (* Compile a list of arguments [e1; ...; eN] to a primitive operation.

--- a/bytecomp/bytegen.ml
+++ b/bytecomp/bytegen.ml
@@ -130,8 +130,7 @@ let preserve_tailcall_for_prim = function
   | Pbytes_load_32 _ | Pbytes_load_64 _ | Pbytes_set_16 _ | Pbytes_set_32 _
   | Pbytes_set_64 _ | Pbigstring_load_16 _ | Pbigstring_load_32 _
   | Pbigstring_load_64 _ | Pbigstring_set_16 _ | Pbigstring_set_32 _
-  | Pbigstring_set_64 _ | Pctconst _ | Pbswap16 | Pbbswap _ | Pint_as_pointer
-  | Pendregion ->
+  | Pbigstring_set_64 _ | Pctconst _ | Pbswap16 | Pbbswap _ | Pint_as_pointer ->
       false
 
 (* Add a Kpop N instruction in front of a continuation *)
@@ -990,7 +989,7 @@ let rec comp_expr env exp sz cont =
       end
   | Lifused (_, exp) ->
       comp_expr env exp sz cont
-  | Lbeginregion (_, exp) ->
+  | Lregion exp ->
       comp_expr env exp sz cont
 
 (* Compile a list of arguments [e1; ...; eN] to a primitive operation.

--- a/dune
+++ b/dune
@@ -174,9 +174,9 @@
 (executable
  (name main)
  (modes byte)
- (flags (:standard -principal -nostdlib))
+ (flags (:standard -principal -nostdlib -ccopt -Iruntime))
  (libraries ocamlbytecomp ocamlcommon runtime stdlib)
- (modules main))
+ (modules maindriver main))
 
 (rule
  (copy main.exe ocamlc.byte))

--- a/dune
+++ b/dune
@@ -13,7 +13,7 @@
 ;**************************************************************************
 
 (env
- (dev     (flags (:standard -w +a-4-9-40-41-42-44-45-48)))
+ (dev     (flags (:standard -w +a-4-9-40-41-42-44-45-48 -warn-error -A)))
  (release (flags (:standard -w +a-4-9-40-41-42-44-45-48))))
 
 ;; Too annoying to get to work. Use (copy_files# ...) instead
@@ -146,6 +146,9 @@
  (libraries stdlib ocamlcommon ocamlmiddleend)
  (modules_without_implementation x86_ast)
  (modules
+   ;; file_formats/
+   linear_format
+
    ;; asmcomp/
    afl_instrument arch asmgen asmlibrarian asmlink asmpackager branch_relaxation
    branch_relaxation_intf cmm_helpers cmm cmmgen cmmgen_state coloring comballoc
@@ -160,7 +163,7 @@
    compute_ranges
 
    ;; driver/
-   optcompile opterrors
+   optcompile opterrors optmaindriver
  )
 )
 
@@ -185,7 +188,7 @@
 (executable
  (name optmain)
  (modes byte)
- (flags (:standard -principal -nostdlib))
+ (flags (:standard -principal -nostdlib -ccopt -Iruntime))
  (libraries ocamloptcomp ocamlmiddleend ocamlcommon runtime stdlib)
  (modules optmain))
 

--- a/lambda/lambda.mli
+++ b/lambda/lambda.mli
@@ -156,8 +156,6 @@ type primitive =
   | Pint_as_pointer
   (* Inhibition of optimisation *)
   | Popaque
-  (* Freeing of locally-allocated data *)
-  | Pendregion
 
 and integer_comparison =
     Ceq | Cne | Clt | Cgt | Cle | Cge
@@ -294,7 +292,7 @@ type lambda =
   | Lsend of meth_kind * lambda * lambda * lambda list * scoped_location
   | Levent of lambda * lambda_event
   | Lifused of Ident.t * lambda
-  | Lbeginregion of Ident.t * lambda
+  | Lregion of lambda
 
 and lfunction =
   { kind: function_kind;

--- a/lambda/lambda.mli
+++ b/lambda/lambda.mli
@@ -45,6 +45,10 @@ type is_safe =
   | Safe
   | Unsafe
 
+type alloc_mode =
+  | Alloc_heap
+  | Alloc_local
+
 type primitive =
   | Pidentity
   | Pbytes_to_string
@@ -56,7 +60,7 @@ type primitive =
   | Pgetglobal of Ident.t
   | Psetglobal of Ident.t
   (* Operations on heap blocks *)
-  | Pmakeblock of int * mutable_flag * block_shape
+  | Pmakeblock of int * mutable_flag * block_shape * alloc_mode
   | Pfield of int
   | Pfield_computed
   | Psetfield of int * immediate_or_pointer * initialization_or_assignment
@@ -152,6 +156,8 @@ type primitive =
   | Pint_as_pointer
   (* Inhibition of optimisation *)
   | Popaque
+  (* Freeing of locally-allocated data *)
+  | Pendregion
 
 and integer_comparison =
     Ceq | Cne | Clt | Cgt | Cle | Cge
@@ -288,6 +294,7 @@ type lambda =
   | Lsend of meth_kind * lambda * lambda * lambda list * scoped_location
   | Levent of lambda * lambda_event
   | Lifused of Ident.t * lambda
+  | Lbeginregion of Ident.t * lambda
 
 and lfunction =
   { kind: function_kind;

--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -3496,7 +3496,7 @@ let rec map_return f = function
   | ( Lvar _ | Lconst _ | Lapply _ | Lfunction _ | Lsend _ | Lprim _ | Lwhile _
     | Lfor _ | Lassign _ | Lifused _ ) as l ->
       f l
-  | Lbeginregion (r, l) -> Lbeginregion (r, map_return f l)
+  | Lregion l -> Lregion (map_return f l)
 
 (* The 'opt' reference indicates if the optimization is worthy.
 

--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -3344,7 +3344,7 @@ let failure_handler ~scopes loc ~failer () =
     Lprim
       ( Praise Raise_regular,
         [ Lprim
-            ( Pmakeblock (0, Immutable, None),
+            ( Pmakeblock (0, Immutable, None, Alloc_heap),
               [ slot;
                 Lconst
                   (Const_block
@@ -3496,6 +3496,7 @@ let rec map_return f = function
   | ( Lvar _ | Lconst _ | Lapply _ | Lfunction _ | Lsend _ | Lprim _ | Lwhile _
     | Lfor _ | Lassign _ | Lifused _ ) as l ->
       f l
+  | Lbeginregion (r, l) -> Lbeginregion (r, map_return f l)
 
 (* The 'opt' reference indicates if the optimization is worthy.
 
@@ -3685,7 +3686,8 @@ let do_for_multiple_match ~scopes loc paraml pat_act_list partial =
       | Total -> (-1, Default_environment.empty)
     in
     let loc = Scoped_location.of_location ~scopes loc in
-    let arg = Lprim (Pmakeblock (0, Immutable, None), paraml, loc) in
+    let arg = Lprim (Pmakeblock (0, Immutable, None, Alloc_heap (* FIXME *)),
+                     paraml, loc) in
     ( raise_num,
       arg,
       { cases = List.map (fun (pat, act) -> ([ pat ], act)) pat_act_list;

--- a/lambda/simplif.ml
+++ b/lambda/simplif.ml
@@ -90,8 +90,8 @@ let rec eliminate_ref id = function
       Levent(eliminate_ref id l, ev)
   | Lifused(v, e) ->
       Lifused(v, eliminate_ref id e)
-  | Lbeginregion (r, e) ->
-      Lbeginregion(r, eliminate_ref id e)
+  | Lregion e ->
+      Lregion(eliminate_ref id e)
 
 (* Simplification of exits *)
 
@@ -167,7 +167,7 @@ let simplify_exits lam =
   | Lsend(_k, m, o, ll, _) -> List.iter count (m::o::ll)
   | Levent(l, _) -> count l
   | Lifused(_v, l) -> count l
-  | Lbeginregion (_r, l) -> count l
+  | Lregion l -> count l
 
   and count_default sw = match sw.sw_failaction with
   | None -> ()
@@ -327,7 +327,7 @@ let simplify_exits lam =
       Lsend(k, simplif m, simplif o, List.map simplif ll, loc)
   | Levent(l, ev) -> Levent(simplif l, ev)
   | Lifused(v, l) -> Lifused (v,simplif l)
-  | Lbeginregion (r, l) -> Lbeginregion (r, simplif l)
+  | Lregion l -> Lregion (simplif l)
   in
   simplif lam
 
@@ -470,8 +470,8 @@ let simplify_lets lam =
   | Levent(l, _) -> count bv l
   | Lifused(v, l) ->
       if count_var v > 0 then count bv l
-  | Lbeginregion (r, l) ->
-      count (bind_var bv r) l
+  | Lregion l ->
+      count bv l
 
   and count_default bv sw = match sw.sw_failaction with
   | None -> ()
@@ -604,7 +604,7 @@ let simplify_lets lam =
   | Levent(l, ev) -> Levent(simplif l, ev)
   | Lifused(v, l) ->
       if count_var v > 0 then simplif l else lambda_unit
-  | Lbeginregion (r, l) -> Lbeginregion (r, simplif l)
+  | Lregion l -> Lregion (simplif l)
   in
   simplif lam
 
@@ -695,8 +695,8 @@ let rec emit_tail_infos is_tail lambda =
       emit_tail_infos is_tail lam
   | Lifused (_, lam) ->
       emit_tail_infos is_tail lam
-  | Lbeginregion (_, lam) ->
-      emit_tail_infos false lam (* FIXME is_tail *)
+  | Lregion lam ->
+      emit_tail_infos false lam
 and list_emit_tail_infos_fun f is_tail =
   List.iter (fun x -> emit_tail_infos is_tail (f x))
 and list_emit_tail_infos is_tail =

--- a/lambda/translclass.ml
+++ b/lambda/translclass.ml
@@ -677,7 +677,7 @@ let free_methods l =
     | Lvar _ | Lconst _ | Lapply _
     | Lprim _ | Lswitch _ | Lstringswitch _ | Lstaticraise _
     | Lifthenelse _ | Lsequence _ | Lwhile _
-    | Levent _ | Lifused _ | Lbeginregion _ -> ()
+    | Levent _ | Lifused _ | Lregion _ -> ()
   in free l; !fv
 
 let transl_class ~scopes ids cl_id pub_meths cl vflag =

--- a/lambda/translcore.mli
+++ b/lambda/translcore.mli
@@ -28,9 +28,11 @@ val transl_apply: scopes:scopes
                   -> ?tailcall:tailcall_attribute
                   -> ?inlined:inline_attribute
                   -> ?specialised:specialise_attribute
-                  -> lambda -> (arg_label * expression option) list
+                  -> lambda -> ?mode:Lambda.alloc_mode
+                  -> (arg_label * expression option) list
                   -> scoped_location -> lambda
-val transl_let: scopes:scopes -> ?in_structure:bool -> rec_flag
+val transl_let: scopes:scopes -> ?in_structure:bool ->
+                ?mode:Lambda.alloc_mode -> rec_flag
                 -> value_binding list -> lambda -> lambda
 
 val transl_extension_constructor: scopes:scopes ->

--- a/lambda/translmod.ml
+++ b/lambda/translmod.ml
@@ -86,7 +86,7 @@ let rec apply_coercion loc strict restr arg =
           else Lprim(Pfield pos,[Lvar id], loc)
         in
         let lam =
-          Lprim(Pmakeblock(0, Immutable, None),
+          Lprim(Pmakeblock(0, Immutable, None, Alloc_heap),
                 List.map (apply_coercion_field loc get_field) pos_cc_list,
                 loc)
         in
@@ -542,7 +542,7 @@ and transl_structure ~scopes loc fields cc rootpath final_env = function
       let body, size =
         match cc with
           Tcoerce_none ->
-            Lprim(Pmakeblock(0, Immutable, None),
+            Lprim(Pmakeblock(0, Immutable, None, Alloc_heap),
                   List.map (fun id -> Lvar id) (List.rev fields), loc),
               List.length fields
         | Tcoerce_structure(pos_cc_list, id_pos_list) ->
@@ -558,7 +558,7 @@ and transl_structure ~scopes loc fields cc rootpath final_env = function
             in
             let ids = List.fold_right Ident.Set.add fields Ident.Set.empty in
             let lam =
-              Lprim(Pmakeblock(0, Immutable, None),
+              Lprim(Pmakeblock(0, Immutable, None, Alloc_heap),
                   List.map
                     (fun (pos, cc) ->
                       match cc with
@@ -1065,7 +1065,7 @@ let transl_store_structure ~scopes glob map prims aliases str =
             Lsequence(lam,
                       Llet(Strict, Pgenval, id,
                            Lambda.subst no_env_update subst
-                             (Lprim(Pmakeblock(0, Immutable, None),
+                             (Lprim(Pmakeblock(0, Immutable, None, Alloc_heap),
                                     List.map (fun id -> Lvar id)
                                       (defined_idents str.str_items), loc)),
                            Lsequence(store_ident loc id,
@@ -1097,7 +1097,7 @@ let transl_store_structure ~scopes glob map prims aliases str =
             Lsequence(lam,
                       Llet(Strict, Pgenval, id,
                            Lambda.subst no_env_update subst
-                             (Lprim(Pmakeblock(0, Immutable, None),
+                             (Lprim(Pmakeblock(0, Immutable, None, Alloc_heap),
                                     List.map field map, loc)),
                            Lsequence(store_ident loc id,
                                      transl_store ~scopes rootpath
@@ -1590,13 +1590,13 @@ let transl_package_flambda component_names coercion =
   in
   size,
   apply_coercion Loc_unknown Strict coercion
-    (Lprim(Pmakeblock(0, Immutable, None),
+    (Lprim(Pmakeblock(0, Immutable, None, Alloc_heap),
            List.map get_component component_names,
            Loc_unknown))
 
 let transl_package component_names target_name coercion =
   let components =
-    Lprim(Pmakeblock(0, Immutable, None),
+    Lprim(Pmakeblock(0, Immutable, None, Alloc_heap),
           List.map get_component component_names, Loc_unknown) in
   Lprim(Psetglobal target_name,
         [apply_coercion Loc_unknown Strict coercion components],
@@ -1634,7 +1634,7 @@ let transl_store_package component_names target_name coercion =
          0 component_names)
   | Tcoerce_structure (pos_cc_list, _id_pos_list) ->
       let components =
-        Lprim(Pmakeblock(0, Immutable, None),
+        Lprim(Pmakeblock(0, Immutable, None, Alloc_heap),
               List.map get_component component_names,
               Loc_unknown)
       in

--- a/lambda/translobj.ml
+++ b/lambda/translobj.ml
@@ -178,7 +178,7 @@ let oo_wrap env req f x =
            List.fold_left
              (fun lambda id ->
                 Llet(StrictOpt, Pgenval, id,
-                     Lprim(Pmakeblock(0, Mutable, None),
+                     Lprim(Pmakeblock(0, Mutable, None, Alloc_heap),
                            [lambda_unit; lambda_unit; lambda_unit],
                            Loc_unknown),
                      lambda))

--- a/lambda/translprim.ml
+++ b/lambda/translprim.ml
@@ -126,8 +126,8 @@ let primitives_table =
     "%field0", Primitive ((Pfield 0), 1);
     "%field1", Primitive ((Pfield 1), 1);
     "%setfield0", Primitive ((Psetfield(0, Pointer, Assignment)), 2);
-    "%makeblock", Primitive ((Pmakeblock(0, Immutable, None)), 1);
-    "%makemutable", Primitive ((Pmakeblock(0, Mutable, None)), 1);
+    "%makeblock", Primitive ((Pmakeblock(0, Immutable, None, Alloc_heap)), 1);
+    "%makemutable", Primitive ((Pmakeblock(0, Mutable, None, Alloc_heap)), 1);
     "%raise", Raise Raise_regular;
     "%reraise", Raise Raise_reraise;
     "%raise_notrace", Raise Raise_notrace;
@@ -461,10 +461,11 @@ let specialize_primitive env ty ~has_constant_constructor prim =
       | Pbigarray_unknown, Pbigarray_unknown_layout -> None
       | _, _ -> Some (Primitive (Pbigarrayset(unsafe, n, k, l), arity))
     end
-  | Primitive (Pmakeblock(tag, mut, None), arity), fields -> begin
+  | Primitive (Pmakeblock(tag, mut, None, mode), arity), fields -> begin
       let shape = List.map (Typeopt.value_kind env) fields in
       let useful = List.exists (fun knd -> knd <> Pgenval) shape in
-      if useful then Some (Primitive (Pmakeblock(tag, mut, Some shape), arity))
+      if useful then
+        Some (Primitive (Pmakeblock(tag, mut, Some shape, mode),arity))
       else None
     end
   | Comparison(comp, Compare_generic), p1 :: _ ->
@@ -684,7 +685,7 @@ let lambda_of_prim prim_name prim loc args arg_exps =
       lambda_of_loc kind loc
   | Loc kind, [arg] ->
       let lam = lambda_of_loc kind loc in
-      Lprim(Pmakeblock(0, Immutable, None), [lam; arg], loc)
+      Lprim(Pmakeblock(0, Immutable, None, Alloc_heap), [lam; arg], loc)
   | Send, [obj; meth] ->
       Lsend(Public, meth, obj, [], loc)
   | Send_self, [obj; meth] ->
@@ -769,7 +770,8 @@ let lambda_primitive_needs_event_after = function
   | Pfloatcomp _ | Pstringlength | Pstringrefu | Pbyteslength | Pbytesrefu
   | Pbytessetu | Pmakearray ((Pintarray | Paddrarray | Pfloatarray), _)
   | Parraylength _ | Parrayrefu _ | Parraysetu _ | Pisint | Pisout
-  | Pintofbint _ | Pctconst _ | Pbswap16 | Pint_as_pointer | Popaque -> false
+  | Pintofbint _ | Pctconst _ | Pbswap16 | Pint_as_pointer | Popaque
+  | Pendregion -> false
 
 (* Determine if a primitive should be surrounded by an "after" debug event *)
 let primitive_needs_event_after = function

--- a/lambda/translprim.ml
+++ b/lambda/translprim.ml
@@ -770,8 +770,8 @@ let lambda_primitive_needs_event_after = function
   | Pfloatcomp _ | Pstringlength | Pstringrefu | Pbyteslength | Pbytesrefu
   | Pbytessetu | Pmakearray ((Pintarray | Paddrarray | Pfloatarray), _)
   | Parraylength _ | Parrayrefu _ | Parraysetu _ | Pisint | Pisout
-  | Pintofbint _ | Pctconst _ | Pbswap16 | Pint_as_pointer | Popaque
-  | Pendregion -> false
+  | Pintofbint _ | Pctconst _ | Pbswap16 | Pint_as_pointer | Popaque ->
+     false
 
 (* Determine if a primitive should be surrounded by an "after" debug event *)
 let primitive_needs_event_after = function

--- a/middle_end/clambda.ml
+++ b/middle_end/clambda.ml
@@ -73,6 +73,7 @@ and ulambda =
   | Uassign of Backend_var.t * ulambda
   | Usend of meth_kind * ulambda * ulambda * ulambda list * Debuginfo.t
   | Uunreachable
+  | Ubeginregion of Backend_var.With_provenance.t * ulambda
 
 and ufunction = {
   label  : function_label;

--- a/middle_end/clambda.ml
+++ b/middle_end/clambda.ml
@@ -73,7 +73,7 @@ and ulambda =
   | Uassign of Backend_var.t * ulambda
   | Usend of meth_kind * ulambda * ulambda * ulambda list * Debuginfo.t
   | Uunreachable
-  | Ubeginregion of Backend_var.With_provenance.t * ulambda
+  | Uregion of ulambda
 
 and ufunction = {
   label  : function_label;

--- a/middle_end/clambda.mli
+++ b/middle_end/clambda.mli
@@ -84,7 +84,7 @@ and ulambda =
   | Uassign of Backend_var.t * ulambda
   | Usend of meth_kind * ulambda * ulambda * ulambda list * Debuginfo.t
   | Uunreachable
-  | Ubeginregion of Backend_var.With_provenance.t * ulambda
+  | Uregion of ulambda
 
 and ufunction = {
   label  : function_label;

--- a/middle_end/clambda.mli
+++ b/middle_end/clambda.mli
@@ -84,6 +84,7 @@ and ulambda =
   | Uassign of Backend_var.t * ulambda
   | Usend of meth_kind * ulambda * ulambda * ulambda list * Debuginfo.t
   | Uunreachable
+  | Ubeginregion of Backend_var.With_provenance.t * ulambda
 
 and ufunction = {
   label  : function_label;

--- a/middle_end/clambda_primitives.ml
+++ b/middle_end/clambda_primitives.ml
@@ -116,8 +116,6 @@ type primitive =
   | Pint_as_pointer
   (* Inhibition of optimisation *)
   | Popaque
-  (* Freeing of locally-allocated data *)
-  | Pendregion
 
 and integer_comparison = Lambda.integer_comparison =
     Ceq | Cne | Clt | Cgt | Cle | Cge

--- a/middle_end/clambda_primitives.ml
+++ b/middle_end/clambda_primitives.ml
@@ -33,7 +33,7 @@ type memory_access_size =
 type primitive =
   | Pread_symbol of string
   (* Operations on heap blocks *)
-  | Pmakeblock of int * mutable_flag * block_shape
+  | Pmakeblock of int * mutable_flag * block_shape * Lambda.alloc_mode
   | Pfield of int
   | Pfield_computed
   | Psetfield of int * immediate_or_pointer * initialization_or_assignment
@@ -116,6 +116,8 @@ type primitive =
   | Pint_as_pointer
   (* Inhibition of optimisation *)
   | Popaque
+  (* Freeing of locally-allocated data *)
+  | Pendregion
 
 and integer_comparison = Lambda.integer_comparison =
     Ceq | Cne | Clt | Cgt | Cle | Cge

--- a/middle_end/clambda_primitives.mli
+++ b/middle_end/clambda_primitives.mli
@@ -33,7 +33,7 @@ type memory_access_size =
 type primitive =
   | Pread_symbol of string
   (* Operations on heap blocks *)
-  | Pmakeblock of int * mutable_flag * block_shape
+  | Pmakeblock of int * mutable_flag * block_shape * Lambda.alloc_mode
   | Pfield of int
   | Pfield_computed
   | Psetfield of int * immediate_or_pointer * initialization_or_assignment
@@ -119,6 +119,8 @@ type primitive =
   | Pint_as_pointer
   (* Inhibition of optimisation *)
   | Popaque
+  (* Freeing of locally-allocated data *)
+  | Pendregion
 
 and integer_comparison = Lambda.integer_comparison =
     Ceq | Cne | Clt | Cgt | Cle | Cge

--- a/middle_end/clambda_primitives.mli
+++ b/middle_end/clambda_primitives.mli
@@ -119,8 +119,6 @@ type primitive =
   | Pint_as_pointer
   (* Inhibition of optimisation *)
   | Popaque
-  (* Freeing of locally-allocated data *)
-  | Pendregion
 
 and integer_comparison = Lambda.integer_comparison =
     Ceq | Cne | Clt | Cgt | Cle | Cge

--- a/middle_end/convert_primitives.ml
+++ b/middle_end/convert_primitives.ml
@@ -24,8 +24,8 @@ let convert_unsafety is_unsafe : Clambda_primitives.is_safe =
 
 let convert (prim : Lambda.primitive) : Clambda_primitives.primitive =
   match prim with
-  | Pmakeblock (tag, mutability, shape) ->
-      Pmakeblock (tag, mutability, shape)
+  | Pmakeblock (tag, mutability, shape, mode) ->
+      Pmakeblock (tag, mutability, shape, mode)
   | Pfield field -> Pfield field
   | Pfield_computed -> Pfield_computed
   | Psetfield (field, imm_or_pointer, init_or_assign) ->
@@ -140,6 +140,7 @@ let convert (prim : Lambda.primitive) : Clambda_primitives.primitive =
   | Pbswap16 -> Pbswap16
   | Pint_as_pointer -> Pint_as_pointer
   | Popaque -> Popaque
+  | Pendregion -> Pendregion
 
   | Pbytes_to_string
   | Pbytes_of_string

--- a/middle_end/convert_primitives.ml
+++ b/middle_end/convert_primitives.ml
@@ -140,7 +140,6 @@ let convert (prim : Lambda.primitive) : Clambda_primitives.primitive =
   | Pbswap16 -> Pbswap16
   | Pint_as_pointer -> Pint_as_pointer
   | Popaque -> Popaque
-  | Pendregion -> Pendregion
 
   | Pbytes_to_string
   | Pbytes_of_string

--- a/middle_end/flambda/build_export_info.ml
+++ b/middle_end/flambda/build_export_info.ml
@@ -280,7 +280,7 @@ and descr_of_named (env : Env.t) (named : Flambda.named)
     Value_id (Env.new_descr env (descr_of_constant const))
   | Allocated_const const ->
     Value_id (Env.new_descr env (descr_of_allocated_constant const))
-  | Prim (Pmakeblock (tag, Immutable, _value_kind), args, _dbg) ->
+  | Prim (Pmakeblock (tag, Immutable, _value_kind, _mode), args, _dbg) ->
     let approxs = List.map (Env.find_approx env) args in
     let descr : Export_info.descr =
       Value_block (Tag.create_exn tag, Array.of_list approxs)

--- a/middle_end/flambda/closure_conversion.ml
+++ b/middle_end/flambda/closure_conversion.ml
@@ -565,8 +565,8 @@ let rec close t env (lam : Lambda.lambda) : Flambda.t =
        or by completely removing it (replacing by unit). *)
     Misc.fatal_error "[Lifused] should have been removed by \
         [Simplif.simplify_lets]"
-  | Lbeginregion _ ->
-    Misc.fatal_error "FIXME: Lbeginregion unimplemented in Flambda"
+  | Lregion _ ->
+    Misc.fatal_error "FIXME: Lregion unimplemented in Flambda"
 
 (** Perform closure conversion on a set of function declarations, returning a
     set of closures.  (The set will often only contain a single function;

--- a/middle_end/flambda/closure_conversion.ml
+++ b/middle_end/flambda/closure_conversion.ml
@@ -565,6 +565,8 @@ let rec close t env (lam : Lambda.lambda) : Flambda.t =
        or by completely removing it (replacing by unit). *)
     Misc.fatal_error "[Lifused] should have been removed by \
         [Simplif.simplify_lets]"
+  | Lbeginregion _ ->
+    Misc.fatal_error "FIXME: Lbeginregion unimplemented in Flambda"
 
 (** Perform closure conversion on a set of function declarations, returning a
     set of closures.  (The set will often only contain a single function;

--- a/middle_end/flambda/inconstant_idents.ml
+++ b/middle_end/flambda/inconstant_idents.ml
@@ -335,7 +335,7 @@ module Inconstants (P:Param) (Backend:Backend_intf.S) = struct
        makeblock(Mutable) can be a 'constant' if it is allocated at
        toplevel: if this expression is evaluated only once.
     *)
-    | Prim (Pmakeblock (_tag, Asttypes.Immutable, _value_kind), args,
+    | Prim (Pmakeblock (_tag, Asttypes.Immutable, _value_kind, _mode), args,
             _dbg) ->
       mark_vars args curr
 (*  (* CR-someday pchambart: If global mutables are allowed: *)

--- a/middle_end/flambda/lift_constants.ml
+++ b/middle_end/flambda/lift_constants.ml
@@ -59,7 +59,7 @@ let assign_symbols_and_collect_constant_definitions
         (* [Inconstant_idents] always marks these expressions as
            inconstant, so we should never get here. *)
         assert false
-      | Prim (Pmakeblock (tag, _, _value_kind), fields, _) ->
+      | Prim (Pmakeblock (tag, _, _value_kind, _mode), fields, _) ->
         assign_symbol ();
         record_definition (AA.Block (Tag.create_exn tag, fields))
       | Read_symbol_field (symbol, field) ->

--- a/middle_end/flambda/lift_let_to_initialize_symbol.ml
+++ b/middle_end/flambda/lift_let_to_initialize_symbol.ml
@@ -81,7 +81,8 @@ let rec accumulate ~substitution ~copied_lets ~extracted_lets
     let extracted =
       let renamed = Variable.rename var in
       match named with
-      | Prim (Pmakeblock (tag, Asttypes.Immutable, _value_kind), args, _dbg) ->
+      | Prim (Pmakeblock (tag, Asttypes.Immutable, _value_kind, Alloc_heap),
+              args, _dbg) ->
         let tag = Tag.create_exn tag in
         let args =
           List.map (fun v ->
@@ -127,7 +128,7 @@ let rec accumulate ~substitution ~copied_lets ~extracted_lets
         Flambda_utils.toplevel_substitution def_substitution
           (Let_rec (renamed_defs,
                     Flambda_utils.name_expr ~name
-                      (Prim (Pmakeblock (0, Immutable, None),
+                      (Prim (Pmakeblock (0, Immutable, None, Alloc_heap),
                              List.map fst renamed_defs,
                              Debuginfo.none))))
       in

--- a/middle_end/flambda/ref_to_variables.ml
+++ b/middle_end/flambda/ref_to_variables.ml
@@ -91,7 +91,7 @@ let variables_containing_ref (flam:Flambda.t) =
   let aux (flam : Flambda.t) =
     match flam with
     | Let { var;
-            defining_expr = Prim(Pmakeblock(0, Asttypes.Mutable, _), l, _);
+            defining_expr = Prim(Pmakeblock(0, Asttypes.Mutable, _, _), l, _);
           } ->
       map := Variable.Map.add var (List.length l) !map
     | _ -> ()
@@ -127,7 +127,7 @@ let eliminate_ref_of_expr flam =
     let aux (flam : Flambda.t) : Flambda.t =
       match flam with
       | Let { var;
-              defining_expr = Prim(Pmakeblock(0, Asttypes.Mutable, shape), l,_);
+              defining_expr = Prim(Pmakeblock(0, Asttypes.Mutable, shape, _mode), l,_);
               body }
         when convertible_variable var ->
         let shape = match shape with

--- a/middle_end/flambda/simplify_primitives.ml
+++ b/middle_end/flambda/simplify_primitives.ml
@@ -108,7 +108,7 @@ let primitive (p : Clambda_primitives.primitive) (args, approxs)
     : Flambda.named * A.t * Inlining_cost.Benefit.t =
   let fpc = !Clflags.float_const_prop in
   match p with
-  | Pmakeblock(tag_int, Asttypes.Immutable, shape) ->
+  | Pmakeblock(tag_int, Asttypes.Immutable, shape, mode) ->
     let tag = Tag.create_exn tag_int in
     let shape = match shape with
       | None -> List.map (fun _ -> Lambda.Pgenval) args
@@ -116,12 +116,12 @@ let primitive (p : Clambda_primitives.primitive) (args, approxs)
     in
     let approxs = List.map2 A.augment_with_kind approxs shape in
     let shape = List.map2 A.augment_kind_with_approx approxs shape in
-    Prim (Pmakeblock(tag_int, Asttypes.Immutable, Some shape), args, dbg),
+    Prim (Pmakeblock(tag_int, Asttypes.Immutable, Some shape, mode), args, dbg),
     A.value_block tag (Array.of_list approxs), C.Benefit.zero
   | Praise _ ->
     expr, A.value_bottom, C.Benefit.zero
   | Pmakearray(_, _) when is_empty approxs ->
-    Prim (Pmakeblock(0, Asttypes.Immutable, Some []), [], dbg),
+    Prim (Pmakeblock(0, Asttypes.Immutable, Some [], Alloc_heap), [], dbg),
     A.value_block (Tag.create_exn 0) [||], C.Benefit.zero
   | Pmakearray (Pfloatarray, Mutable) ->
       let approx =

--- a/middle_end/flambda/un_anf.ml
+++ b/middle_end/flambda/un_anf.ml
@@ -231,7 +231,7 @@ let make_var_info (clam : Clambda.ulambda) : var_info =
       ignore_debuginfo dbg
     | Uunreachable ->
       ()
-    | Ubeginregion (_r, e) ->
+    | Uregion e ->
       loop ~depth e
   in
   loop ~depth:0 clam;
@@ -449,9 +449,9 @@ let let_bound_vars_that_can_be_moved var_info (clam : Clambda.ulambda) =
       ignore_debuginfo dbg
     | Uunreachable ->
       let_stack := []
-    | Ubeginregion (_r, e) ->
+    | Uregion e ->
       let_stack := [];
-      loop e  (* FIXME is this correct? *)
+      loop e
   in
   loop clam;
   !can_move
@@ -595,9 +595,9 @@ let rec substitute_let_moveable is_let_moveable env (clam : Clambda.ulambda)
     Usend (kind, e1, e2, args, dbg)
   | Uunreachable ->
     Uunreachable
-  | Ubeginregion (r, e) ->
+  | Uregion e ->
     let e = substitute_let_moveable is_let_moveable env e in
-    Ubeginregion (r, e)
+    Uregion (e)
 
 and substitute_let_moveable_list is_let_moveable env clams =
   List.map (substitute_let_moveable is_let_moveable env) clams
@@ -822,9 +822,9 @@ let rec un_anf_and_moveable var_info env (clam : Clambda.ulambda)
     Usend (kind, e1, e2, args, dbg), Fixed
   | Uunreachable ->
     Uunreachable, Fixed
-  | Ubeginregion (r, e) ->
+  | Uregion e ->
     let e = un_anf var_info env e in
-    Ubeginregion (r, e), Fixed
+    Uregion e, Fixed
 
 and un_anf var_info env clam : Clambda.ulambda =
   let clam, _moveable = un_anf_and_moveable var_info env clam in

--- a/middle_end/internal_variable_names.ml
+++ b/middle_end/internal_variable_names.ml
@@ -172,7 +172,6 @@ let psubfloat = "Psubfloat"
 let psubint = "Psubint"
 let pxorbint = "Pxorbint"
 let pxorint = "Pxorint"
-let pendregion = "Pendregion"
 let pabsfloat_arg = "Pabsfloat_arg"
 let paddbint_arg = "Paddbint_arg"
 let paddfloat_arg = "Paddfloat_arg"
@@ -278,7 +277,6 @@ let psubfloat_arg = "Psubfloat_arg"
 let psubint_arg = "Psubint_arg"
 let pxorbint_arg = "Pxorbint_arg"
 let pxorint_arg = "Pxorint_arg"
-let pendregion_arg = "Pendregion_arg"
 let raise = "raise"
 let raise_arg = "raise_arg"
 let read_mutable = "read_mutable"
@@ -416,7 +414,6 @@ let of_primitive : Lambda.primitive -> string = function
   | Pbbswap _ -> pbbswap
   | Pint_as_pointer -> pint_as_pointer
   | Popaque -> popaque
-  | Pendregion -> pendregion
 
 let of_primitive_arg : Lambda.primitive -> string = function
   | Pidentity -> pidentity_arg
@@ -523,4 +520,3 @@ let of_primitive_arg : Lambda.primitive -> string = function
   | Pbbswap _ -> pbbswap_arg
   | Pint_as_pointer -> pint_as_pointer_arg
   | Popaque -> popaque_arg
-  | Pendregion -> pendregion_arg

--- a/middle_end/internal_variable_names.ml
+++ b/middle_end/internal_variable_names.ml
@@ -172,6 +172,7 @@ let psubfloat = "Psubfloat"
 let psubint = "Psubint"
 let pxorbint = "Pxorbint"
 let pxorint = "Pxorint"
+let pendregion = "Pendregion"
 let pabsfloat_arg = "Pabsfloat_arg"
 let paddbint_arg = "Paddbint_arg"
 let paddfloat_arg = "Paddfloat_arg"
@@ -277,6 +278,7 @@ let psubfloat_arg = "Psubfloat_arg"
 let psubint_arg = "Psubint_arg"
 let pxorbint_arg = "Pxorbint_arg"
 let pxorint_arg = "Pxorint_arg"
+let pendregion_arg = "Pendregion_arg"
 let raise = "raise"
 let raise_arg = "raise_arg"
 let read_mutable = "read_mutable"
@@ -414,6 +416,7 @@ let of_primitive : Lambda.primitive -> string = function
   | Pbbswap _ -> pbbswap
   | Pint_as_pointer -> pint_as_pointer
   | Popaque -> popaque
+  | Pendregion -> pendregion
 
 let of_primitive_arg : Lambda.primitive -> string = function
   | Pidentity -> pidentity_arg
@@ -520,3 +523,4 @@ let of_primitive_arg : Lambda.primitive -> string = function
   | Pbbswap _ -> pbbswap_arg
   | Pint_as_pointer -> pint_as_pointer_arg
   | Popaque -> popaque_arg
+  | Pendregion -> pendregion_arg

--- a/middle_end/printclambda.ml
+++ b/middle_end/printclambda.ml
@@ -235,6 +235,8 @@ and lam ppf = function
       fprintf ppf "@[<2>(send%s@ %a@ %a%a)@]" kind lam obj lam met args largs
   | Uunreachable ->
       fprintf ppf "unreachable"
+  | Ubeginregion (r, e) ->
+      fprintf ppf "@[<2>(region@ %a@ %a)@]" VP.print r lam e
 
 and sequence ppf ulam = match ulam with
   | Usequence(l1, l2) ->

--- a/middle_end/printclambda.ml
+++ b/middle_end/printclambda.ml
@@ -235,8 +235,8 @@ and lam ppf = function
       fprintf ppf "@[<2>(send%s@ %a@ %a%a)@]" kind lam obj lam met args largs
   | Uunreachable ->
       fprintf ppf "unreachable"
-  | Ubeginregion (r, e) ->
-      fprintf ppf "@[<2>(region@ %a@ %a)@]" VP.print r lam e
+  | Uregion e ->
+      fprintf ppf "@[<2>(region@ %a)@]" lam e
 
 and sequence ppf ulam = match ulam with
   | Usequence(l1, l2) ->

--- a/middle_end/printclambda_primitives.ml
+++ b/middle_end/printclambda_primitives.ml
@@ -207,4 +207,3 @@ let primitive ppf (prim:Clambda_primitives.primitive) =
   | Pbbswap(bi) -> print_boxed_integer "bswap" ppf bi
   | Pint_as_pointer -> fprintf ppf "int_as_pointer"
   | Popaque -> fprintf ppf "opaque"
-  | Pendregion -> fprintf ppf "endregion"

--- a/middle_end/printclambda_primitives.ml
+++ b/middle_end/printclambda_primitives.ml
@@ -57,10 +57,14 @@ let primitive ppf (prim:Clambda_primitives.primitive) =
   match prim with
   | Pread_symbol sym ->
       fprintf ppf "read_symbol %s" sym
-  | Pmakeblock(tag, Immutable, shape) ->
-      fprintf ppf "makeblock %i%a" tag Printlambda.block_shape shape
-  | Pmakeblock(tag, Mutable, shape) ->
-      fprintf ppf "makemutable %i%a" tag Printlambda.block_shape shape
+  | Pmakeblock(tag, mut, shape, mode) ->
+      let kind =
+        match mut, mode with
+        | Immutable, Alloc_heap -> "block"
+        | Mutable, Alloc_heap -> "mutable"
+        | Immutable, Alloc_local -> "localblock"
+        | Mutable, Alloc_local -> "localmutable" in
+      fprintf ppf "make%s %i%a" kind tag Printlambda.block_shape shape
   | Pfield n -> fprintf ppf "field %i" n
   | Pfield_computed -> fprintf ppf "field_computed"
   | Psetfield(n, ptr, init) ->
@@ -203,3 +207,4 @@ let primitive ppf (prim:Clambda_primitives.primitive) =
   | Pbbswap(bi) -> print_boxed_integer "bswap" ppf bi
   | Pint_as_pointer -> fprintf ppf "int_as_pointer"
   | Popaque -> fprintf ppf "opaque"
+  | Pendregion -> fprintf ppf "endregion"

--- a/middle_end/semantics_of_primitives.ml
+++ b/middle_end/semantics_of_primitives.ml
@@ -135,7 +135,6 @@ let for_primitive (prim : Clambda_primitives.primitive) =
   | Psequor ->
       (* Removed by [Closure_conversion] in the flambda pipeline. *)
       No_effects, No_coeffects
-  | Pendregion -> Arbitrary_effects, Has_coeffects
 
 type return_type =
   | Float

--- a/middle_end/semantics_of_primitives.ml
+++ b/middle_end/semantics_of_primitives.ml
@@ -21,9 +21,11 @@ type coeffects = No_coeffects | Has_coeffects
 
 let for_primitive (prim : Clambda_primitives.primitive) =
   match prim with
-  | Pmakeblock _
+  | Pmakeblock (_, _, _, Lambda.Alloc_heap)
   | Pmakearray (_, Mutable) -> Only_generative_effects, No_coeffects
   | Pmakearray (_, Immutable) -> No_effects, No_coeffects
+  | Pmakeblock (_, _, _, Lambda.Alloc_local) ->
+     Only_generative_effects, Has_coeffects
   | Pduparray (_, Immutable) ->
       No_effects, No_coeffects  (* Pduparray (_, Immutable) is allowed only on
                                    immutable arrays. *)

--- a/middle_end/semantics_of_primitives.ml
+++ b/middle_end/semantics_of_primitives.ml
@@ -133,6 +133,7 @@ let for_primitive (prim : Clambda_primitives.primitive) =
   | Psequor ->
       (* Removed by [Closure_conversion] in the flambda pipeline. *)
       No_effects, No_coeffects
+  | Pendregion -> Arbitrary_effects, Has_coeffects
 
 type return_type =
   | Float

--- a/runtime/amd64.S
+++ b/runtime/amd64.S
@@ -445,6 +445,100 @@ CFI_STARTPROC
 CFI_ENDPROC
 ENDFUNCTION(G(caml_allocN))
 
+
+
+FUNCTION(G(caml_call_local_realloc))
+        CFI_STARTPROC
+    /* Touch the stack to trigger a recoverable segfault
+       if insufficient space remains */
+        subq    $(STACK_PROBE_SIZE), %rsp; CFI_ADJUST(STACK_PROBE_SIZE);
+        movq    %r11, 0(%rsp)
+        addq    $(STACK_PROBE_SIZE), %rsp; CFI_ADJUST(-STACK_PROBE_SIZE);
+    /* Build array of registers, save it into Caml_state->gc_regs */
+#ifdef WITH_FRAME_POINTERS
+        ENTER_FUNCTION          ;
+#else
+        pushq   %rbp; CFI_ADJUST(8);
+#endif
+        pushq   %r11; CFI_ADJUST (8);
+        pushq   %r10; CFI_ADJUST (8);
+        pushq   %r13; CFI_ADJUST (8);
+        pushq   %r12; CFI_ADJUST (8);
+        pushq   %r9; CFI_ADJUST (8);
+        pushq   %r8; CFI_ADJUST (8);
+        pushq   %rcx; CFI_ADJUST (8);
+        pushq   %rdx; CFI_ADJUST (8);
+        pushq   %rsi; CFI_ADJUST (8);
+        pushq   %rdi; CFI_ADJUST (8);
+        pushq   %rbx; CFI_ADJUST (8);
+        pushq   %rax; CFI_ADJUST (8);
+        movq    %rsp, Caml_state(gc_regs)
+    /* Save young_ptr */
+        movq    %r15, Caml_state(young_ptr)
+    /* Save floating-point registers */
+        subq    $(16*8), %rsp; CFI_ADJUST (16*8);
+        movsd   %xmm0, 0*8(%rsp)
+        movsd   %xmm1, 1*8(%rsp)
+        movsd   %xmm2, 2*8(%rsp)
+        movsd   %xmm3, 3*8(%rsp)
+        movsd   %xmm4, 4*8(%rsp)
+        movsd   %xmm5, 5*8(%rsp)
+        movsd   %xmm6, 6*8(%rsp)
+        movsd   %xmm7, 7*8(%rsp)
+        movsd   %xmm8, 8*8(%rsp)
+        movsd   %xmm9, 9*8(%rsp)
+        movsd   %xmm10, 10*8(%rsp)
+        movsd   %xmm11, 11*8(%rsp)
+        movsd   %xmm12, 12*8(%rsp)
+        movsd   %xmm13, 13*8(%rsp)
+        movsd   %xmm14, 14*8(%rsp)
+        movsd   %xmm15, 15*8(%rsp)
+    /* Call the garbage collector */
+        PREPARE_FOR_C_CALL
+        call    GCALL(caml_local_realloc)
+        CLEANUP_AFTER_C_CALL
+    /* Restore young_ptr */
+        movq    Caml_state(young_ptr), %r15
+    /* Restore all regs used by the code generator */
+        movsd   0*8(%rsp), %xmm0
+        movsd   1*8(%rsp), %xmm1
+        movsd   2*8(%rsp), %xmm2
+        movsd   3*8(%rsp), %xmm3
+        movsd   4*8(%rsp), %xmm4
+        movsd   5*8(%rsp), %xmm5
+        movsd   6*8(%rsp), %xmm6
+        movsd   7*8(%rsp), %xmm7
+        movsd   8*8(%rsp), %xmm8
+        movsd   9*8(%rsp), %xmm9
+        movsd   10*8(%rsp), %xmm10
+        movsd   11*8(%rsp), %xmm11
+        movsd   12*8(%rsp), %xmm12
+        movsd   13*8(%rsp), %xmm13
+        movsd   14*8(%rsp), %xmm14
+        movsd   15*8(%rsp), %xmm15
+        addq    $(16*8), %rsp; CFI_ADJUST(-16*8)
+        popq    %rax; CFI_ADJUST(-8)
+        popq    %rbx; CFI_ADJUST(-8)
+        popq    %rdi; CFI_ADJUST(-8)
+        popq    %rsi; CFI_ADJUST(-8)
+        popq    %rdx; CFI_ADJUST(-8)
+        popq    %rcx; CFI_ADJUST(-8)
+        popq    %r8; CFI_ADJUST(-8)
+        popq    %r9; CFI_ADJUST(-8)
+        popq    %r12; CFI_ADJUST(-8)
+        popq    %r13; CFI_ADJUST(-8)
+        popq    %r10; CFI_ADJUST(-8)
+        popq    %r11; CFI_ADJUST(-8)
+#ifdef WITH_FRAME_POINTERS
+        LEAVE_FUNCTION
+#else
+        popq    %rbp; CFI_ADJUST(-8);
+#endif
+    /* Return to caller */
+        ret
+CFI_ENDPROC
+ENDFUNCTION(G(caml_call_local_realloc))
+
 /* Call a C function from OCaml */
 
 FUNCTION(G(caml_c_call))

--- a/runtime/caml/domain_state.tbl
+++ b/runtime/caml/domain_state.tbl
@@ -36,6 +36,10 @@ DOMAIN_STATE(struct caml_ephe_ref_table*, ephe_ref_table)
 DOMAIN_STATE(struct caml_custom_table*, custom_table)
 /* See minor_gc.c */
 
+DOMAIN_STATE(intnat, local_sp)
+DOMAIN_STATE(struct region_stack*, local_top)
+DOMAIN_STATE(intnat, local_limit)
+
 DOMAIN_STATE(struct mark_stack*, mark_stack)
 /* See major_gc.c */
 

--- a/typing/env.ml
+++ b/typing/env.ml
@@ -212,6 +212,8 @@ module TycompTbl =
   end
 
 
+type empty = |
+
 module IdTbl =
   struct
     (** This module is used to store all kinds of components except
@@ -220,15 +222,15 @@ module IdTbl =
         bindings between each of them. *)
 
 
-    type ('a, 'b) t = {
+    type ('lock, 'a, 'b) t = {
       current: 'a Ident.tbl;
-      (** Local bindings since the last open *)
+      (** Local bindings since the last open or lock *)
 
-      layer: ('a, 'b) layer;
+      layer: ('lock, 'a, 'b) layer;
       (** Symbolic representation of the last (innermost) open, if any. *)
     }
 
-    and ('a, 'b) layer =
+    and ('lock, 'a, 'b) layer =
       | Open of {
           root: Path.t;
           (** The path of the opened module, to be prefixed in front of
@@ -243,13 +245,18 @@ module IdTbl =
               "open".  This is used to detect unused "opens".  The
               arguments are used to detect shadowing. *)
 
-          next: ('a, 'b) t;
+          next: ('lock, 'a, 'b) t;
           (** The table before opening the module. *)
         }
 
       | Map of {
           f: ('a -> 'a);
-          next: ('a, 'b) t;
+          next: ('lock, 'a, 'b) t;
+        }
+
+      | Lock of {
+          mode: 'lock;
+          next: ('lock, 'a, 'b) t;
         }
 
       | Nothing
@@ -273,6 +280,10 @@ module IdTbl =
         layer = Open {using; root; components; next};
       }
 
+    let add_lock mode next =
+      (* FIXME optimisation: shared lock on shared ctx should be no-op *)
+      { current = Ident.empty; layer = Lock {mode; next} }
+
     let map f next =
       {
         current = Ident.empty;
@@ -285,37 +296,49 @@ module IdTbl =
         begin match tbl.layer with
         | Open {next; _} -> find_same id next
         | Map {f; next} -> f (find_same id next)
+        | Lock {mode=_; next} -> find_same id next
         | Nothing -> raise exn
         end
 
-    let rec find_name wrap ~mark name tbl =
+    let rec find_name_and_locks wrap ~mark name tbl macc =
       try
         let (id, desc) = Ident.find_name name tbl.current in
-        Pident id, desc
+        Pident id, macc, desc
       with Not_found as exn ->
         begin match tbl.layer with
         | Open {using; root; next; components} ->
             begin try
               let descr = wrap (NameMap.find name components) in
-              let res = Pdot (root, name), descr in
+              let res = Pdot (root, name), macc, descr in
               if mark then begin match using with
               | None -> ()
               | Some f -> begin
-                  match find_name wrap ~mark:false name next with
+                  match find_name_and_locks wrap ~mark:false name next macc with
                   | exception Not_found -> f name None
-                  | _, descr' -> f name (Some (descr', descr))
+                  | _, _, descr' -> f name (Some (descr', descr))
                 end
               end;
               res
             with Not_found ->
-              find_name wrap ~mark name next
+              find_name_and_locks wrap ~mark name next macc
             end
         | Map {f; next} ->
-            let (p, desc) =  find_name wrap ~mark name next in
-            p, f desc
+            let (p, macc, desc) =
+              find_name_and_locks wrap ~mark name next macc in
+            p, macc, f desc
+        | Lock {mode; next} ->
+            find_name_and_locks wrap ~mark name next (mode :: macc)
         | Nothing ->
             raise exn
         end
+
+    let find_name_and_modes wrap ~mark name tbl =
+      find_name_and_locks wrap ~mark name tbl []
+
+    let find_name wrap ~mark name tbl =
+      let (id, ([] : empty list), desc) =
+        find_name_and_modes wrap ~mark name tbl in
+      id, desc
 
     let rec find_all wrap name tbl =
       List.map
@@ -333,6 +356,8 @@ module IdTbl =
       | Map {f; next} ->
           List.map (fun (p, desc) -> (p, f desc))
             (find_all wrap name next)
+      | Lock {mode=_;next} ->
+          find_all wrap name next
 
     let rec fold_name wrap f tbl acc =
       let acc =
@@ -354,11 +379,13 @@ module IdTbl =
           |> fold_name wrap
                (fun name (path, desc) -> f name (path, g desc))
                next
+      | Lock {mode=_; next} ->
+          fold_name wrap f next acc
 
     let rec local_keys tbl acc =
       let acc = Ident.fold_all (fun k _ accu -> k::accu) tbl.current acc in
       match tbl.layer with
-      | Open {next; _ } | Map {next; _} -> local_keys next acc
+      | Open {next; _ } | Map {next; _} | Lock {next; _} -> local_keys next acc
       | Nothing -> acc
 
 
@@ -375,6 +402,8 @@ module IdTbl =
           iter wrap f next
       | Map {f=g; next} ->
           iter wrap (fun id (path, desc) -> f id (path, g desc)) next
+      | Lock {mode=_; next} ->
+          iter wrap f next
       | Nothing -> ()
 
     let diff_keys tbl1 tbl2 =
@@ -394,14 +423,14 @@ type type_descriptions =
 let in_signature_flag = 0x01
 
 type t = {
-  values: (value_entry, value_data) IdTbl.t;
+  values: (alloc_mode, value_entry, value_data) IdTbl.t;
   constrs: constructor_data TycompTbl.t;
   labels: label_data TycompTbl.t;
-  types: (type_data, type_data) IdTbl.t;
-  modules: (module_entry, module_data) IdTbl.t;
-  modtypes: (modtype_data, modtype_data) IdTbl.t;
-  classes: (class_data, class_data) IdTbl.t;
-  cltypes: (cltype_data, cltype_data) IdTbl.t;
+  types: (empty, type_data, type_data) IdTbl.t;
+  modules: (empty, module_entry, module_data) IdTbl.t;
+  modtypes: (empty, modtype_data, modtype_data) IdTbl.t;
+  classes: (empty, class_data, class_data) IdTbl.t;
+  cltypes: (empty, cltype_data, cltype_data) IdTbl.t;
   functor_args: unit Ident.tbl;
   summary: summary;
   local_constraints: type_declaration Path.Map.t;
@@ -465,7 +494,8 @@ and address_lazy = (address_unforced, address) EnvLazy.t
 
 and value_data =
   { vda_description : value_description;
-    vda_address : address_lazy }
+    vda_address : address_lazy;
+    vda_mode : alloc_mode }
 
 and value_entry =
   | Val_bound of value_data
@@ -534,6 +564,8 @@ type lookup_error =
   | Generative_used_as_applicative of Longident.t
   | Illegal_reference_to_recursive_module
   | Cannot_scrape_alias of Longident.t * Path.t
+  | Local_value_escapes of Longident.t
+  | Local_value_used_in_closure of Longident.t
 
 type error =
   | Missing_module of Location.t * Path.t * Path.t
@@ -1544,7 +1576,9 @@ let rec components_of_module_maker
               | Val_prim _ -> EnvLazy.create_failed Not_found
               | _ -> next_address ()
             in
-            let vda = { vda_description = decl'; vda_address = addr } in
+            let vda = { vda_description = decl';
+                        vda_address = addr;
+                        vda_mode = Alloc_heap } in
             c.comp_values <- NameMap.add (Ident.name id) vda c.comp_values;
         | Sig_type(id, decl, _, _) ->
             let fresh_decl =
@@ -1692,12 +1726,12 @@ and check_value_name name loc =
         error (Illegal_value_name(loc, name))
     done
 
-and store_value ?check id addr decl env =
+and store_value ?check mode id addr decl env =
   check_value_name (Ident.name id) decl.val_loc;
   Option.iter
     (fun f -> check_usage decl.val_loc id decl.val_uid f !value_declarations)
     check;
-  let vda = { vda_description = decl; vda_address = addr } in
+  let vda = { vda_description = decl; vda_address = addr; vda_mode = mode } in
   { env with
     values = IdTbl.add id (Val_bound vda) env.values;
     summary = Env_value(env.summary, id, decl) }
@@ -1878,9 +1912,9 @@ let add_functor_arg id env =
    functor_args = Ident.add id () env.functor_args;
    summary = Env_functor_arg (env.summary, id)}
 
-let add_value ?check id desc env =
+let add_value ?check ?(mode = Alloc_heap) id desc env =
   let addr = value_declaration_address env id desc in
-  store_value ?check id addr desc env
+  store_value ?check mode id addr desc env
 
 let add_type ~check id info env =
   store_type ~check id info env
@@ -1925,7 +1959,7 @@ let add_local_type path info env =
 let enter_value ?check name desc env =
   let id = Ident.create_local name in
   let addr = value_declaration_address env id desc in
-  let env = store_value ?check id addr desc env in
+  let env = store_value ?check Alloc_heap id addr desc env in
   (id, env)
 
 let enter_type ~scope name info env =
@@ -1961,6 +1995,9 @@ let enter_cltype ~scope name desc env =
 
 let enter_module ~scope ?arg s presence mty env =
   enter_module_declaration ~scope ?arg s presence (md mty) env
+
+let add_lock mode env =
+  { env with values = IdTbl.add_lock mode env.values }
 
 (* Insertion of all components of a signature *)
 
@@ -2377,12 +2414,22 @@ let lookup_ident_module (type a) (load : a load) ~errors ~use ~loc s env =
         end
     end
 
-let lookup_ident_value ~errors ~use ~loc name env =
-  match IdTbl.find_name wrap_value ~mark:use name env.values with
-  | (path, Val_bound vda) ->
+let constrain_modes ~errors ~loc env id vmode locks mode =
+  let constrain m n err =
+    match Alloc_mode.constrain m n with
+    | Ok () -> ()
+    | Error () -> may_lookup_error errors loc env err in
+  constrain vmode mode (Local_value_escapes id);
+  locks |> List.iter (fun l ->
+    constrain vmode l (Local_value_used_in_closure id))
+
+let lookup_ident_value ~errors ~use ~loc name mode env =
+  match IdTbl.find_name_and_modes wrap_value ~mark:use name env.values with
+  | (path, locks, Val_bound vda) ->
+      constrain_modes ~errors ~loc env (Lident name) vda.vda_mode locks mode;
       use_value ~use ~loc path vda;
       path, vda.vda_description
-  | (_, Val_unbound reason) ->
+  | (_, _, Val_unbound reason) ->
       report_value_unbound ~errors ~loc env reason (Lident name)
   | exception Not_found ->
       may_lookup_error errors loc env (Unbound_value (Lident name, No_hint))
@@ -2613,9 +2660,9 @@ let lookup_module_path ~errors ~use ~loc ~load lid env : Path.t =
       check_functor_appl ~errors ~loc env p1 f arg p2 md2;
       Papply(p1, p2)
 
-let lookup_value ~errors ~use ~loc lid env =
+let lookup_value ~errors ~use ~loc lid mode env =
   match lid with
-  | Lident s -> lookup_ident_value ~errors ~use ~loc s env
+  | Lident s -> lookup_ident_value ~errors ~use ~loc s mode env
   | Ldot(l, s) -> lookup_dot_value ~errors ~use ~loc l s env
   | Lapply _ -> assert false
 
@@ -2701,7 +2748,7 @@ let find_module_by_name lid env =
 
 let find_value_by_name lid env =
   let loc = Location.(in_file !input_name) in
-  lookup_value ~errors:false ~use:false ~loc lid env
+  lookup_value ~errors:false ~use:false ~loc lid Alloc_mode.max_mode env
 
 let find_type_by_name lid env =
   let loc = Location.(in_file !input_name) in
@@ -2776,8 +2823,10 @@ let lookup_all_labels_from_type ?(use=true) ~loc ty_path env =
   lookup_all_labels_from_type ~use ~loc ty_path env
 
 let lookup_instance_variable ?(use=true) ~loc name env =
-  match IdTbl.find_name wrap_value ~mark:use name env.values with
-  | (path, Val_bound vda) -> begin
+  match IdTbl.find_name_and_modes wrap_value ~mark:use name env.values with
+  | (path, locks, Val_bound vda) -> begin
+      constrain_modes ~errors:true ~loc env (Lident name)
+        vda.vda_mode locks Alloc_heap;
       let desc = vda.vda_description in
       match desc.val_kind with
       | Val_ivar(mut, cl_num) ->
@@ -2786,13 +2835,13 @@ let lookup_instance_variable ?(use=true) ~loc name env =
       | _ ->
           lookup_error loc env (Not_an_instance_variable name)
     end
-  | (_, Val_unbound Val_unbound_instance_variable) ->
+  | (_, _, Val_unbound Val_unbound_instance_variable) ->
       lookup_error loc env (Masked_instance_variable (Lident name))
-  | (_, Val_unbound Val_unbound_self) ->
+  | (_, _, Val_unbound Val_unbound_self) ->
       lookup_error loc env (Not_an_instance_variable name)
-  | (_, Val_unbound Val_unbound_ancestor) ->
+  | (_, _, Val_unbound Val_unbound_ancestor) ->
       lookup_error loc env (Not_an_instance_variable name)
-  | (_, Val_unbound Val_unbound_ghost_recursive _) ->
+  | (_, _, Val_unbound Val_unbound_ghost_recursive _) ->
       lookup_error loc env (Unbound_instance_variable name)
   | exception Not_found ->
       lookup_error loc env (Unbound_instance_variable name)
@@ -2811,7 +2860,7 @@ let bound_module name env =
       end
 
 let bound wrap proj name env =
-  match IdTbl.find_name wrap ~mark:false name (proj env) with
+  match IdTbl.find_name_and_modes wrap ~mark:false name (proj env) with
   | _ -> true
   | exception Not_found -> false
 
@@ -3196,6 +3245,15 @@ let report_lookup_error _loc env ppf = function
       fprintf ppf
         "The module %a is an alias for module %a, which %s"
         !print_longident lid !print_path p cause
+  | Local_value_escapes lid ->
+      fprintf ppf
+        "@[The value %a is local, so cannot be used here as it might escape@]"
+        !print_longident lid
+  | Local_value_used_in_closure lid ->
+      fprintf ppf
+        "@[The value %a is local, so cannot be used \
+           inside a closure that might escape@]"
+        !print_longident lid
 
 let report_error ppf = function
   | Missing_module(_, path1, path2) ->

--- a/typing/env.mli
+++ b/typing/env.mli
@@ -168,6 +168,8 @@ type lookup_error =
   | Generative_used_as_applicative of Longident.t
   | Illegal_reference_to_recursive_module
   | Cannot_scrape_alias of Longident.t * Path.t
+  | Local_value_escapes of Longident.t
+  | Local_value_used_in_closure of Longident.t
 
 val lookup_error: Location.t -> t -> lookup_error -> 'a
 
@@ -184,7 +186,7 @@ val lookup_error: Location.t -> t -> lookup_error -> 'a
    emitted the wrong number of times. *)
 
 val lookup_value:
-  ?use:bool -> loc:Location.t -> Longident.t -> t ->
+  ?use:bool -> loc:Location.t -> Longident.t -> Types.alloc_mode -> t ->
   Path.t * value_description
 val lookup_type:
   ?use:bool -> loc:Location.t -> Longident.t -> t ->
@@ -263,7 +265,8 @@ val make_copy_of_types: t -> (t -> t)
 (* Insertion by identifier *)
 
 val add_value:
-    ?check:(string -> Warnings.t) -> Ident.t -> value_description -> t -> t
+    ?check:(string -> Warnings.t) -> ?mode:(Types.Alloc_mode.t) ->
+    Ident.t -> value_description -> t -> t
 val add_type: check:bool -> Ident.t -> type_declaration -> t -> t
 val add_extension:
   check:bool -> rebind:bool -> Ident.t -> extension_constructor -> t -> t
@@ -339,6 +342,9 @@ val enter_signature: scope:int -> signature -> t -> signature * t
 val enter_unbound_value : string -> value_unbound_reason -> t -> t
 
 val enter_unbound_module : string -> module_unbound_reason -> t -> t
+
+(* Lock the environment *)
+val add_lock : Types.Alloc_mode.t -> t -> t
 
 (* Initialize the cache of in-core module interfaces. *)
 val reset_cache: unit -> unit

--- a/typing/printtyped.ml
+++ b/typing/printtyped.ml
@@ -314,7 +314,7 @@ and expression i ppf x =
                       expression_extra i ppf extra attrs; i+1)
       (i+1) x.exp_extra
   in
-  if x.exp_mode <> Types.Alloc_heap then
+  if x.exp_mode <> Types.Alloc_mode.Alloc_heap then
     line i ppf "alloc_mode %s\n"
       (match x.exp_mode with Alloc_heap -> "heap" | Alloc_local -> "local");
   match x.exp_desc with

--- a/typing/printtyped.ml
+++ b/typing/printtyped.ml
@@ -314,6 +314,9 @@ and expression i ppf x =
                       expression_extra i ppf extra attrs; i+1)
       (i+1) x.exp_extra
   in
+  if x.exp_mode <> Types.Alloc_heap then
+    line i ppf "alloc_mode %s\n"
+      (match x.exp_mode with Alloc_heap -> "heap" | Alloc_local -> "local");
   match x.exp_desc with
   | Texp_ident (li,_,_) -> line i ppf "Texp_ident %a\n" fmt_path li;
   | Texp_instvar (_, li,_) -> line i ppf "Texp_instvar %a\n" fmt_path li;

--- a/typing/typeclass.ml
+++ b/typing/typeclass.ml
@@ -1044,6 +1044,7 @@ and class_expr_aux cl_num val_env met_env scl =
               Texp_ident(path, mknoloc (Longident.Lident (Ident.name id)), vd);
               exp_loc = Location.none; exp_extra = [];
               exp_type = Ctype.instance vd.val_type;
+              exp_mode = Alloc_heap;
               exp_attributes = []; (* check *)
               exp_env = val_env'})
           end
@@ -1194,6 +1195,7 @@ and class_expr_aux cl_num val_env met_env scl =
                 Texp_ident(path, mknoloc(Longident.Lident (Ident.name id)),vd);
                 exp_loc = Location.none; exp_extra = [];
                 exp_type = Ctype.instance vd.val_type;
+                exp_mode = Alloc_heap;
                 exp_attributes = [];
                 exp_env = val_env;
                }

--- a/typing/typecore.mli
+++ b/typing/typecore.mli
@@ -103,7 +103,6 @@ val check_partial:
         ?lev:int -> Env.t -> type_expr ->
         Location.t -> Typedtree.value Typedtree.case list -> Typedtree.partial
 val type_expect:
-        ?in_function:(Location.t * type_expr) ->
         Env.t -> Parsetree.expression -> type_expected -> Typedtree.expression
 val type_exp:
         Env.t -> Parsetree.expression -> Typedtree.expression

--- a/typing/typedtree.ml
+++ b/typing/typedtree.ml
@@ -85,6 +85,7 @@ and expression =
     exp_loc: Location.t;
     exp_extra: (exp_extra * Location.t * attribute list) list;
     exp_type: type_expr;
+    exp_mode: alloc_mode;
     exp_env: Env.t;
     exp_attributes: attribute list;
    }

--- a/typing/typedtree.mli
+++ b/typing/typedtree.mli
@@ -150,6 +150,7 @@ and expression =
     exp_loc: Location.t;
     exp_extra: (exp_extra * Location.t * attributes) list;
     exp_type: Types.type_expr;
+    exp_mode: Types.alloc_mode;
     exp_env: Env.t;
     exp_attributes: attributes;
    }

--- a/typing/types.ml
+++ b/typing/types.ml
@@ -471,3 +471,5 @@ let signature_item_id = function
   | Sig_class (id, _, _, _)
   | Sig_class_type (id, _, _, _)
     -> id
+
+type alloc_mode = Alloc_heap | Alloc_local (* FIXME *)

--- a/typing/types.ml
+++ b/typing/types.ml
@@ -472,4 +472,19 @@ let signature_item_id = function
   | Sig_class_type (id, _, _, _)
     -> id
 
-type alloc_mode = Alloc_heap | Alloc_local (* FIXME *)
+type alloc_mode = Alloc_heap | Alloc_local
+
+module Alloc_mode = struct
+  type t = alloc_mode = Alloc_heap | Alloc_local
+
+  let min_mode = Alloc_heap
+  let is_min = function Alloc_heap -> true | _ -> false
+
+  let max_mode = Alloc_local
+  let is_max = function Alloc_local -> true | _ -> false
+
+  let constrain a b =
+    match a, b with
+    | Alloc_heap, _ | _, Alloc_local -> Ok ()
+    | Alloc_local, Alloc_heap -> Error ()
+end

--- a/typing/types.mli
+++ b/typing/types.mli
@@ -584,3 +584,5 @@ type label_description =
 val bound_value_identifiers: signature -> Ident.t list
 
 val signature_item_id : signature_item -> Ident.t
+
+type alloc_mode = Alloc_heap | Alloc_local (* FIXME *)

--- a/typing/types.mli
+++ b/typing/types.mli
@@ -585,4 +585,17 @@ val bound_value_identifiers: signature -> Ident.t list
 
 val signature_item_id : signature_item -> Ident.t
 
-type alloc_mode = Alloc_heap | Alloc_local (* FIXME *)
+type alloc_mode = Alloc_heap | Alloc_local
+
+module Alloc_mode : sig
+  type t = alloc_mode = Alloc_heap | Alloc_local
+  
+  val min_mode : t
+  val is_min : t -> bool
+
+  val max_mode : t
+  val is_max : t -> bool
+
+  val constrain : t -> t -> (unit, unit) result
+end
+


### PR DESCRIPTION
This is the start of a prototype to add escape analysis and stack allocation via modal types to OCaml. 

This first patch is mostly plumbing. There's a couple of FIXMEs in the code, some of which we should figure out during review and some of which should wait for a later patch.

The features in this patch are:

### Typing
  - A new exp_mode field in Typedtree nodes
  - Enough plumbing of mode values through Typecore to fill in exp_mode with stub values
  - Modes and locking in typing environments (although without much of interest to do with them)

### Lambda
  - New region operations `Lbeginregion` and `Pendregion`. Note the asymmetry: starting a region is a block-structured operation. It may be ended at any point with the `Pendregion` primitive. A single `Pendregion` may end multiple regions, as ending an outer region implicitly ends inner regions.
  - Automatic insertion of `Lbeginregion` and `Pendregion` whenever we transition into the stack-allocation mode.
  - Annotations of the `Pmakeblock` primitive with the appropriate allocation mode.

### Backend
  - Plumbing of the new operations through Closure / Clambda / Cmm. By Cmm time, the block structure is gone and the region operations are lowered to external C calls.
  - (Flambda compiles but is untested)

### Assembly / Runtime
  - Basic runtime implementation for amd64 only.
  - External C calls for region manipulation (easy to break on in gdb, but will not perform well)

---

Conspicuously missing (for future patches):

  - Interesting typechecking: the only way to make a stack allocation is `let[@stack]`, which is special-cased in the typechecker and is not checked for soundness.
  - GC support: runtime support so far extends only to performing stack allocations. They're not currently traced during GC, so crashes will occur if they are live across a collection.